### PR TITLE
resolved tag mismatches in GetPlayerButtonList

### DIFF
--- a/button.inc
+++ b/button.inc
@@ -241,7 +241,7 @@ forward GetPlayerButtonID(playerid, &Button:id);
 Returns the closest button that a player is standing within the area of.
 */
 
-forward GetPlayerButtonList(playerid, list[], &size, bool:validate = false);
+forward GetPlayerButtonList(playerid, Button:list[], &size, bool:validate = false);
 /*
 # Description
 Returns a list of buttons that a player is standing in the areas of.
@@ -722,7 +722,7 @@ stock GetPlayerButtonID(playerid, &Button:id) {
 	return 3;
 }
 
-stock GetPlayerButtonList(playerid, list[], &size, bool:validate = false) {
+stock GetPlayerButtonList(playerid, Button:list[], &size, bool:validate = false) {
 	if(!IsPlayerConnected(playerid)) {
 		return 1;
 	}
@@ -744,11 +744,11 @@ stock GetPlayerButtonList(playerid, list[], &size, bool:validate = false) {
 				continue;
 			}
 
-			list[size++] = _:btn_Near[playerid][i];
+			list[size++] = btn_Near[playerid][i];
 		}
 	} else {
 		foreach(new i : btn_NearIndex[playerid]) {
-			list[size++] = _:btn_Near[playerid][i];
+			list[size++] = btn_Near[playerid][i];
 		}
 	}
 

--- a/button.inc
+++ b/button.inc
@@ -738,17 +738,17 @@ stock GetPlayerButtonList(playerid, list[], &size, bool:validate = false) {
 			if(!IsPlayerInDynamicArea(playerid, btn_Data[btn_Near[playerid][i]][btn_area])) {
 				err("player incorrectly flagged as inside button area",
 					_i("playerid", playerid),
-					_i("id", btn_Near[playerid][i]));
+					_i("id", _:btn_Near[playerid][i]));
 
 				Iter_SafeRemove(btn_NearIndex[playerid], i, i);
 				continue;
 			}
 
-			list[size++] = btn_Near[playerid][i];
+			list[size++] = _:btn_Near[playerid][i];
 		}
 	} else {
 		foreach(new i : btn_NearIndex[playerid]) {
-			list[size++] = btn_Near[playerid][i];
+			list[size++] = _:btn_Near[playerid][i];
 		}
 	}
 


### PR DESCRIPTION
`GetPlayerButtonList` previously relayed back the **Buttons** nearby a player in an untagged list.

It's safe to assume the `list` returned will contain values of type `Button:`, evidence to support this gathered from the **Item** module's use of the function, [here](https://github.com/ScavengeSurvive/item/blob/master/item.inc#L1830).

This pull request resolves this issue both in the `forward` declaration and implementation. The list returned by `GetPlayerButtonList` is now typed `Button:` and the values can be used in any of the functions provided by the library.