### PR TITLE
Update to the latest YSI

### DIFF
--- a/button.inc
+++ b/button.inc
@@ -363,7 +363,7 @@ hook OnScriptInit() {
 		btn_Pressing[i] = INVALID_BUTTON_ID;
 	}
 
-	return Y_HOOKS_CONTINUE_RETURN_0;
+	return 0;
 }
 
 hook OnPlayerConnect(playerid) {
@@ -371,7 +371,7 @@ hook OnPlayerConnect(playerid) {
 
 	btn_Pressing[playerid] = INVALID_BUTTON_ID;
 
-	return Y_HOOKS_CONTINUE_RETURN_0;
+	return 0;
 }
 
 
@@ -872,7 +872,7 @@ hook OnPlayerKeyStateChange(playerid, newkeys, oldkeys) {
 		}
 	}
 
-	return Y_HOOKS_CONTINUE_RETURN_1;
+	return 1;
 }
 
 _btn_SortButtons(array[][e_button_range_data], left, right) {
@@ -925,10 +925,6 @@ Internal_OnButtonPress(playerid, Button:id) {
 	}
 
 	return 0;
-}
-
-timer btn_Unfreeze[BTN_TELEPORT_FREEZE_TIME](playerid) {
-	TogglePlayerControllable(playerid, true);
 }
 
 hook OnPlayerEnterDynArea(playerid, areaid) {


### PR DESCRIPTION
Additionally, after recent changes in YSI a new warning started showing up:
```
(warning) symbol is never used: "_yT@btn_Unfreeze"
```

It's caused by this:
```
timer btn_Unfreeze[BTN_TELEPORT_FREEZE_TIME](playerid) {
	TogglePlayerControllable(playerid, true);
}
```

It seems like that timer is some sort of dead code, there are no references to it and the `BTN_TELEPORT_FREEZE_TIME` is not even defined in the include.
I've removed it but if there's any reason to keep it, let me know and I'll add it back.

Full reference for the changes: https://github.com/ScavengeSurvive/language/pull/4